### PR TITLE
fixing a handful of bad/wrong swagger definition properties

### DIFF
--- a/contract/src/main/resources/v1/swagger/animal/path/animalSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/animal/path/animalSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching animals
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/astronomical_object/path/astronomicalObjectSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/astronomical_object/path/astronomicalObjectSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching astronomical objects
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/book/entity/bookFull.yaml
+++ b/contract/src/main/resources/v1/swagger/book/entity/bookFull.yaml
@@ -9,7 +9,6 @@ properties:
     type: string
     required: true
     description: Book title
-    required: true
   publishedYear:
     type: integer
     description: Year the book was published

--- a/contract/src/main/resources/v1/swagger/book/path/bookSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/book/path/bookSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching books
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/book_collection/path/bookCollectionSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/book_collection/path/bookCollectionSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching book collections
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/book_series/path/bookSeriesSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/book_series/path/bookSeriesSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching book series
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/character/path/characterSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/character/path/characterSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching characters
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/comic_collection/path/comicCollectionSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/comic_collection/path/comicCollectionSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching comic collections
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/comic_series/path/comicSeriesSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/comic_series/path/comicSeriesSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching comic series
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/comic_strip/path/comicStripSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/comic_strip/path/comicStripSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching comic strips
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/comics/path/comicsSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/comics/path/comicsSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching comics
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/company/path/companySearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/company/path/companySearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching companies
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/conflict/path/conflictSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/conflict/path/conflictSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching conflicts
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/element/path/elementSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/element/path/elementSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching elements
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/episode/entity/episodeBase.yaml
+++ b/contract/src/main/resources/v1/swagger/episode/entity/episodeBase.yaml
@@ -19,7 +19,7 @@ properties:
     type: string
     description: Episode title in Japanese
   series:
-    $ref: '#/definitions/seriesHeader'
+    $ref: '#/definitions/SeriesHeader'
     description: Series this episode belongs to
   season:
     $ref: '#/definitions/seasonHeader'

--- a/contract/src/main/resources/v1/swagger/episode/entity/episodeBase.yaml
+++ b/contract/src/main/resources/v1/swagger/episode/entity/episodeBase.yaml
@@ -22,7 +22,7 @@ properties:
     $ref: '#/definitions/SeriesHeader'
     description: Series this episode belongs to
   season:
-    $ref: '#/definitions/seasonHeader'
+    $ref: '#/definitions/SeasonHeader'
     description: Season this episode belongs to
   seasonNumber:
     type: integer

--- a/contract/src/main/resources/v1/swagger/episode/path/episodeSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/episode/path/episodeSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching episodes
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/food/path/foodSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/food/path/foodSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching foods
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/literature/path/literatureSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/literature/path/literatureSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching literature
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/location/path/locationSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/location/path/locationSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching locations
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/magazine/path/magazineSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/magazine/path/magazineSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching magazines
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/magazine_series/path/magazineSeriesSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/magazine_series/path/magazineSeriesSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching magazine series
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/material/path/materialSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/material/path/materialSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching materials
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/medical_condition/path/medicalConditionSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/medical_condition/path/medicalConditionSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching medical conditions
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/movie/path/movieSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/movie/path/movieSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching movies
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/occupation/path/occupationSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/occupation/path/occupationSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching occupations
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/organization/path/organizationSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/organization/path/organizationSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching organizations
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/performer/path/performerSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/performer/path/performerSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching performers
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/reference/entity/reference.yaml
+++ b/contract/src/main/resources/v1/swagger/reference/entity/reference.yaml
@@ -3,10 +3,10 @@ description: Reference of book, comics, video release, etc.
 properties:
   uid:
     type: string
-  description: Reference unique ID
+    description: Reference unique ID
   referenceType:
     $ref: '#/definitions/ReferenceType'
-  description: Reference type
+    description: Reference type
   referenceNumber:
     type: string
-  description: Reference number
+    description: Reference number

--- a/contract/src/main/resources/v1/swagger/season/path/seasonSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/season/path/seasonSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching seasons
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/series/entity/seriesBase.yaml
+++ b/contract/src/main/resources/v1/swagger/series/entity/seriesBase.yaml
@@ -37,8 +37,8 @@ properties:
     type: integer
     description: Number of feature length episodes
   productionCompany:
-    $ref: CompanyHeader
+    $ref: ./company/entity/companyHeader.yaml
     description: Company that produced the series
   originalBroadcaster:
-    $ref: CompanyHeader
+    $ref: ./company/entity/companyHeader.yaml
     description: Company that originally broadcasted the series

--- a/contract/src/main/resources/v1/swagger/series/path/seriesSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/series/path/seriesSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching series
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber
@@ -104,4 +104,3 @@ post:
         $ref: '#/definitions/SeriesBaseResponse'
   tags:
     - Series
-

--- a/contract/src/main/resources/v1/swagger/soundtrack/path/soundtrackSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/soundtrack/path/soundtrackSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching soundtracks
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/spacecraft/path/spacecraftSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/spacecraft/path/spacecraftSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching spacecrafts
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/spacecraft_class/path/spacecraftClassSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/spacecraft_class/path/spacecraftClassSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching spacecraft classes
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/species/path/speciesSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/species/path/speciesSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching species
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber
@@ -108,4 +108,3 @@ post:
         $ref: '#/definitions/SpeciesBaseResponse'
   tags:
     - Species
-

--- a/contract/src/main/resources/v1/swagger/staff/path/staffSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/staff/path/staffSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching staff
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/technology/path/technologySearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/technology/path/technologySearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching technology
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/title/path/titleSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/title/path/titleSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching titles
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/trading_card/path/tradingCardSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/trading_card/path/tradingCardSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching trading cards
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/trading_card_deck/path/tradingCardDeckSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/trading_card_deck/path/tradingCardDeckSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching trading card decks
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/trading_card_set/path/tradingCardSetSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/trading_card_set/path/tradingCardSetSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching trading card sets
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/video_game/path/videoGameSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/video_game/path/videoGameSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching video games
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/video_release/path/videoReleaseSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/video_release/path/videoReleaseSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching video releases
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber

--- a/contract/src/main/resources/v1/swagger/weapon/path/weaponSearch.path.yaml
+++ b/contract/src/main/resources/v1/swagger/weapon/path/weaponSearch.path.yaml
@@ -29,7 +29,7 @@ post:
   description: Searching weapons
   consumes:
     - application/x-www-form-urlencoded
-  producers:
+  produces:
     - application/json
   parameters:
     - name: pageNumber


### PR DESCRIPTION
This fixes a handful of bad and wrong Swagger definition properties:

* [x] For almost every path its `produces` property was typod as "producers"
* [x] The `BookFull` definition had a duplicate `required: true`
* [x] The `Reference` definition was all sorts of messed up and had bad indents
* [x] The `SeriesHeader` and `SeasonHeader` definitions were improperly cased.
* [x] A `$ref` to the `CompanyHeader` definition wasn't written right.